### PR TITLE
Fix #2 by adding g++ options for large memory usage. WARNING: 64 BIT ONLY.

### DIFF
--- a/initial.sh
+++ b/initial.sh
@@ -1,6 +1,6 @@
 
 sh pre_process.sh
-g++ -o distance_server distance_server.cpp 
+g++ -fPIC -mcmodel=medium -o distance_server distance_server.cpp 
 g++ -o client client.c
 g++ -std=c++0x -o find_rhyme_words_server find_rhyme_words_server.cpp  
 g++ -std=c++0x -o phrase_to_accepted_phrases_server phrase_to_accepted_phrases_server.cpp 


### PR DESCRIPTION
Added g++ flags:
-fPIC
Adds relative addressing. Helps usage from outside the code itself.
-mcmodel=medium
A **64 Bit** option that allows data more than 2GB. This fixes the error mentioned in Issue #2 in 64 bit systems.

**I have not tested on 32 bit systems**, however, since they're basically not used anymore, that shouldn't be an issue.